### PR TITLE
build(deps): bump vpxtool from 0.27.1 to 0.29.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2036,9 +2036,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2058,9 +2058,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -4588,9 +4588,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pinmame-nvram"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4a576be7b515eec534964e3ec7264586e80c101c0c21cc739fe333a05982af"
+checksum = "fa6098b925391025952a9168cf4c1133ed0c24b0224c158ab24b3bb499a9cc53"
 dependencies = [
  "brotli",
  "include_dir",
@@ -4915,9 +4915,9 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -5982,9 +5982,9 @@ dependencies = [
 
 [[package]]
 name = "vpxtool"
-version = "0.27.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81abd03650d6d81d2a1d9b88c07c953204f6c1c8c507c74441ce8b6100a9101"
+checksum = "30f8b3930ce724e11ee022fe415e866fee06c555d9bdac73b45809e6fc13c8cc"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ path = "src/main.rs"
 
 
 [dependencies]
-vpxtool = "0.27.1"
+vpxtool = "0.29.0"
 bevy = "0.18.1"
 bevy_asset = "0.18.1"
 bevy_dev_tools = "0.18.1"

--- a/src/loading.rs
+++ b/src/loading.rs
@@ -350,11 +350,13 @@ fn load_tables(
         let recursive = true;
         // TODO make a progress that sends events and update loading gui
         let progress = EventSendingProgress { sender: tx.clone() };
+        let global_pinmame = resolved_config.global_pinmame_folder();
         let index_result = vpxtool::indexer::index_folder(
             recursive,
+            None,
             &resolved_config.tables_folder,
             &resolved_config.tables_index_path,
-            Some(&resolved_config.global_pinmame_folder()),
+            Some(global_pinmame.as_path()),
             resolved_config.configured_pinmame_folder().as_deref(),
             &progress,
             Vec::new(),


### PR DESCRIPTION
Adapt to the new index_folder signature, which adds a max_depth parameter and now takes &Path / Option<&Path> for folder arguments.