### PR TITLE
ci: use Swatinem/rust-cache for the clippy workflow

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -19,20 +19,12 @@ jobs:
       - name: Install bevy linux dependencies
         run: sudo apt-get update && sudo apt-get install g++ pkg-config libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0 libwayland-dev libxkbcommon-dev
       - uses: actions/checkout@v6
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install minimal stable with clippy and rustfmt
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2.9.1
       - name: Run clippy
         run: cargo clippy --color always --all-targets --all-features
       - name: Run fmt check


### PR DESCRIPTION
Replace the manual actions/cache (whole ~/.cargo + target/, keyed only on Cargo.lock) with Swatinem/rust-cache, matching rust.yml and the other repos. It prunes local crate artifacts before saving and keys on the rustc version, so it stays smaller and gets better hit rates.