### PR TITLE
ci: add a fast ci build profile (opt-level 0 for deps)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           # PRs read the main cache but don't write their own, to save cache budget.
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - run: cargo clippy --all-targets --all-features
+      - run: cargo clippy --profile ci --all-targets --all-features
 
   test:
     name: Build & test
@@ -63,5 +63,5 @@ jobs:
       - uses: Swatinem/rust-cache@v2.9.1
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - run: cargo build --locked --verbose
-      - run: cargo test --verbose
+      - run: cargo build --locked --profile ci
+      - run: cargo test --profile ci

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,14 @@ opt-level = 1
 # Enable a large amount of optimization in the dev profile for dependencies.
 [profile.dev.package."*"]
 opt-level = 3
+
+# Optimize for build time in CI: don't optimize dependencies, so a cold build
+# (cache miss) doesn't spend ~40 min optimizing all of Bevy at opt-level 3.
+[profile.ci]
+inherits = "dev"
+opt-level = 0
+debug = "line-tables-only"
+codegen-units = 4
+
+[profile.ci.package."*"]
+opt-level = 0


### PR DESCRIPTION
The dev profile builds all dependencies at opt-level 3, so a cold CI build (cache miss) spends ~40 min optimizing all of Bevy. Add a [profile.ci] that inherits dev but drops dependency optimization, and run clippy/build/test with --profile ci.

Cold builds drop to a few minutes and the resulting target/cache is much smaller, so caches stop being evicted past the 10 GB repo limit and warm builds stay warm. Mirrors the profile used in vpinball2d.