### PR TITLE
ci: manage releases with release-plz (no crates.io)

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,64 @@
+name: Release-plz
+
+# Automates versioning: the PR job opens/updates a "release" PR with the next
+# version and changelog; merging it makes the release job create the git tag and
+# GitHub release. The package has `publish = false`, so nothing is sent to
+# crates.io. The created tag triggers the binary build in release.yml.
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  # Create the git tag and GitHub release for the merged version bump.
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'francisdb' && github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          # release-plz uses the PAT below (GITHUB_TOKEN env) for its git push, so
+          # the pushed tag triggers release.yml (the default GITHUB_TOKEN cannot
+          # trigger other workflow runs). Don't persist checkout's own credentials.
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.VPXTOOL_GUI_RELEASE_PLZ_TOKEN }}
+
+  # Open/update a PR with the next version and changelog.
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'francisdb' && github.actor != 'dependabot[bot]' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
 name: Release build
+# Builds the distributable binaries for a version tag created by release-plz and
+# attaches them to the matching GitHub release. Tag-only: no per-commit builds.
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*'
 permissions:
   contents: write
 jobs:
@@ -31,18 +33,17 @@ jobs:
         if: contains(matrix.platform.os, 'ubuntu')
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Install minimal stable with clippy and rustfmt
+      - name: Install minimal stable
         uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2.9.1
+      # No rust-cache here on purpose: releases are infrequent, so a cache would
+      # mostly be evicted between releases while consuming the repo cache budget
+      # that the CI workflow needs.
       - name: Build
         run: cargo build --locked --release
       - name: Set full archive name as env variable
         shell: bash
         run: |
-          VERSION=$(if [[ $GITHUB_REF == refs/tags/* ]]; then echo ${GITHUB_REF#refs/tags/} | sed 's/\//-/g'; else git rev-parse --short $GITHUB_SHA; fi)
+          VERSION=${GITHUB_REF#refs/tags/}
           EXTENSION="tar.gz"
           if [[ "${{ matrix.platform.os }}" == "windows-latest" ]]; then
             EXTENSION="zip"
@@ -62,15 +63,10 @@ jobs:
             tar czvf $ARCHIVE_NAME $ARCHIVE_DIR
           fi
           rm -rf $ARCHIVE_DIR
-      - name: Publish release artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: ${{ env.ARCHIVE_NAME }}
-          path: ${{ env.ARCHIVE_NAME }}
-          if-no-files-found: error
-        if: startsWith( github.ref, 'refs/tags/v' ) == false
-#      - name: Publish GitHub release
-#        uses: softprops/action-gh-release@v2
-#        with:
-#          files: "vpxtool*"
-#        if: startsWith( github.ref, 'refs/tags/v' )
+      - name: Upload archive to the GitHub release
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Attach the asset to the release release-plz already created for this
+        # tag; --clobber replaces it on re-runs and leaves the notes untouched.
+        run: gh release upload "${GITHUB_REF#refs/tags/}" "$ARCHIVE_NAME" --clobber --repo "$GITHUB_REPOSITORY"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6545,7 +6545,7 @@ dependencies = [
 
 [[package]]
 name = "vpxtool_gui"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "bevy",
  "bevy_asset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "vpxtool_gui"
+version = "0.1.0"
 edition = "2024"
+# This is an application binary, not a library; never publish to crates.io.
+# release-plz still creates git tags and GitHub releases.
+publish = false
 
 [[bin]]
 name = "vpxtool-gui"


### PR DESCRIPTION
Add a release-plz workflow that opens version-bump + changelog PRs and, on merge, creates the git tag and GitHub release. The package is marked `publish = false` so nothing goes to crates.io; release-plz still tags and creates the GitHub release.

Rework release.yml to build the distributable binaries only on `v*` tags (no more per-commit nightly builds) and attach them to the release via `gh release upload`. Drop its rust-cache step: releases are infrequent, so the cache mostly gets evicted between them while consuming the repo cache budget the CI workflow needs.

Set an initial version of 0.1.0.

Requires a RELEASE_PLZ_TOKEN repo secret (PAT) so the pushed tag can trigger release.yml; the default GITHUB_TOKEN cannot trigger other workflows.