### PR TITLE
fix: make release-plz manage releases via git_only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,9 +2,6 @@
 name = "vpxtool_gui"
 version = "0.1.0"
 edition = "2024"
-# This is an application binary, not a library; never publish to crates.io.
-# release-plz still creates git tags and GitHub releases.
-publish = false
 
 [[bin]]
 name = "vpxtool-gui"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,6 @@
+# This is an application binary, not a library, so it is never published to
+# crates.io. `git_only` makes release-plz determine the version from git tags
+# (default `v{{ version }}`) and skip `cargo publish`, while still opening
+# version/changelog PRs and creating git tags + GitHub releases.
+[workspace]
+git_only = true


### PR DESCRIPTION
Setting `publish = false` in Cargo.toml made release-plz treat the package as "not released": it never opened a release PR for it (and with the default registry-based version detection it looked for a crate that doesn't exist on crates.io). That's why no release PR appeared even after a feat commit.

Remove the Cargo.toml `publish = false` and instead set `git_only = true` in a release-plz.toml. git_only determines the version from git tags (v{version}, matching the existing v0.1.0) and skips `cargo publish`, while still opening version/changelog PRs and creating git tags + GitHub releases.