### PR TITLE
feat: cycle info panel through description/rules with a scrollbar

### DIFF
--- a/src/info.rs
+++ b/src/info.rs
@@ -5,10 +5,16 @@ use bevy::input::ButtonInput;
 use bevy::input::mouse::{MouseScrollUnit, MouseWheel};
 use bevy::picking::hover::HoverMap;
 use bevy::prelude::*;
+use bevy::ui_widgets::{ControlOrientation, Scrollbar, ScrollbarThumb};
 
 const FONT_SIZE_TITLE: f32 = 20.;
 const FONT_SIZE_BODY: f32 = 14.;
 const LINE_HEIGHT: f32 = 21.;
+
+/// Scrollbar track: a dark, subtle gutter behind the thumb.
+const SCROLLBAR_TRACK: Color = Color::srgba(0.0, 0.0, 0.0, 0.25);
+/// Scrollbar thumb: the draggable handle.
+const SCROLLBAR_THUMB: Color = Color::srgba(0.45, 0.55, 0.70, 0.9);
 
 // marker for the ui node
 #[derive(Component)]
@@ -23,15 +29,25 @@ struct BodyNode;
 #[derive(Component)]
 struct BodyScroller;
 
+/// Which section the info panel shows; `1` cycles Off -> Description -> Rules.
+#[derive(Resource, Default, Clone, Copy, PartialEq, Eq)]
+enum InfoMode {
+    #[default]
+    Off,
+    Description,
+    Rules,
+}
+
 pub(crate) fn info_plugin(app: &mut App) {
-    app.add_systems(Startup, setup)
+    app.init_resource::<InfoMode>()
+        .add_systems(Startup, setup)
         .add_systems(Update, send_scroll_events)
-        .add_systems(Update, toggle_visibility)
-        .add_systems(Update, handle_table_selection_changed)
+        .add_systems(Update, cycle_info_mode)
+        .add_systems(Update, update_info)
         .add_observer(on_scroll_handler);
 }
 
-fn setup(mut commands: Commands, _asset_server: Res<AssetServer>) {
+fn setup(mut commands: Commands) {
     commands
         .spawn((
             Node {
@@ -46,74 +62,173 @@ fn setup(mut commands: Commands, _asset_server: Res<AssetServer>) {
             InfoNode,
         ))
         .with_children(|parent| {
-            parent.spawn((
-                Node {
-                    flex_direction: FlexDirection::Column,
-                    justify_content: JustifyContent::Start,
-                    align_items: AlignItems::Center,
-                    width: percent(100),
-                    ..default()
-                },
-                BackgroundColor(Color::srgb(0.10, 0.10, 0.10)),
-                children![
-                    (
-                        // Title
-                        (
+            parent
+                .spawn((
+                    Node {
+                        flex_direction: FlexDirection::Column,
+                        align_items: AlignItems::Center,
+                        width: percent(100),
+                        height: percent(100),
+                        ..default()
+                    },
+                    BackgroundColor(Color::srgb(0.10, 0.10, 0.10)),
+                ))
+                .with_children(|panel| {
+                    // Title bar
+                    panel
+                        .spawn((
                             Node {
                                 width: Val::Percent(100.0),
                                 padding: UiRect::all(Val::Px(8.0)),
                                 justify_content: JustifyContent::Center,
                                 ..default()
                             },
-                            BackgroundColor(Color::srgb(0.05, 0.05, 0.05))
-                        ),
-                        children![(
-                            Text::new("[No title]"),
-                            TextFont {
-                                font_size: FontSize::Px(FONT_SIZE_TITLE),
-                                ..default()
-                            },
-                            Label,
-                            TitleNode
-                        )],
-                    ),
-                    (
-                        // Scrolling description
-                        Node {
-                            padding: UiRect::all(Val::Px(8.0)),
-                            flex_direction: FlexDirection::Column,
+                            BackgroundColor(Color::srgb(0.05, 0.05, 0.05)),
+                        ))
+                        .with_children(|title| {
+                            title.spawn((
+                                Text::new("[No title]"),
+                                TextFont {
+                                    font_size: FontSize::Px(FONT_SIZE_TITLE),
+                                    ..default()
+                                },
+                                Label,
+                                TitleNode,
+                            ));
+                        });
+
+                    // Scrolling body sits in a row next to a draggable scrollbar.
+                    panel
+                        .spawn(Node {
+                            flex_direction: FlexDirection::Row,
+                            align_items: AlignItems::Stretch,
                             align_self: AlignSelf::Stretch,
-                            overflow: Overflow::scroll_y(), // n.b.
+                            flex_grow: 1.0,
+                            min_height: px(0),
+                            padding: UiRect::all(Val::Px(8.0)),
+                            column_gap: px(6),
                             ..default()
-                        },
-                        BodyScroller,
-                        children![(
-                            Text::new("[no description]"),
-                            TextFont {
-                                font_size: FontSize::Px(FONT_SIZE_BODY),
-                                ..default()
-                            },
-                            BodyNode
-                        )],
-                    ),
-                ],
-            ));
+                        })
+                        .with_children(|row| {
+                            let scroller = row
+                                .spawn((
+                                    Node {
+                                        flex_direction: FlexDirection::Column,
+                                        flex_grow: 1.0,
+                                        min_height: px(0),
+                                        overflow: Overflow::scroll_y(), // n.b.
+                                        ..default()
+                                    },
+                                    BodyScroller,
+                                ))
+                                .with_children(|body| {
+                                    body.spawn((
+                                        Text::new("[no description]"),
+                                        TextFont {
+                                            font_size: FontSize::Px(FONT_SIZE_BODY),
+                                            ..default()
+                                        },
+                                        BodyNode,
+                                    ));
+                                })
+                                .id();
+
+                            // Draggable scrollbar (bevy_ui_widgets headless widget): it
+                            // writes the scroller's ScrollPosition when the thumb is
+                            // dragged. We own the visuals: a track gutter plus a thumb.
+                            row.spawn((
+                                Node {
+                                    width: px(10),
+                                    border_radius: BorderRadius::all(px(5)),
+                                    ..default()
+                                },
+                                BackgroundColor(SCROLLBAR_TRACK),
+                                Scrollbar::new(scroller, ControlOrientation::Vertical, 32.0),
+                                children![(
+                                    ScrollbarThumb {
+                                        border_radius: BorderRadius::all(px(5)),
+                                        ..default()
+                                    },
+                                    BackgroundColor(SCROLLBAR_THUMB),
+                                )],
+                            ));
+                        });
+                });
         });
 }
 
-fn toggle_visibility(
-    mut query: Query<&mut Visibility, With<InfoNode>>,
-    keys: Res<ButtonInput<KeyCode>>,
-) {
+/// `1` cycles the info panel: Off -> Description -> Rules -> Off.
+fn cycle_info_mode(keys: Res<ButtonInput<KeyCode>>, mut mode: ResMut<InfoMode>) {
     if keys.just_pressed(KeyCode::Digit1) {
-        for mut visibility in &mut query {
-            *visibility = if *visibility == Visibility::Visible {
-                Visibility::Hidden
-            } else {
-                Visibility::Visible
-            };
-        }
+        *mode = match *mode {
+            InfoMode::Off => InfoMode::Description,
+            InfoMode::Description => InfoMode::Rules,
+            InfoMode::Rules => InfoMode::Off,
+        };
     }
+}
+
+/// Update the panel's visibility and contents when the mode or selection changes.
+#[allow(clippy::type_complexity, clippy::too_many_arguments)]
+fn update_info(
+    mode: Res<InfoMode>,
+    mut selection_changed: MessageReader<TableSelectionChanged>,
+    selected_item_res: Res<SelectedItem>,
+    tables: Res<VpxTables>,
+    mut info_visibility: Query<&mut Visibility, With<InfoNode>>,
+    mut title_text: Single<&mut Text, With<TitleNode>>,
+    mut body_text: Single<&mut Text, (With<BodyNode>, Without<TitleNode>)>,
+    mut scroll_query: Query<&mut ScrollPosition, With<BodyScroller>>,
+) {
+    let selection_changed = selection_changed.read().count() > 0;
+    if !mode.is_changed() && !selection_changed {
+        return;
+    }
+
+    if let Ok(mut visibility) = info_visibility.single_mut() {
+        *visibility = if *mode == InfoMode::Off {
+            Visibility::Hidden
+        } else {
+            Visibility::Visible
+        };
+    }
+
+    if *mode == InfoMode::Off || tables.indexed_tables.is_empty() {
+        return;
+    }
+
+    let selected = selected_item_res.index.unwrap_or(0);
+    let table = &tables.indexed_tables[selected];
+    let name = display_table_line(table);
+    let (title, body) = match *mode {
+        InfoMode::Description => (
+            name,
+            table
+                .table_info
+                .table_description
+                .clone()
+                .filter(|x| !x.trim().is_empty())
+                .unwrap_or_else(|| "[no description]".to_string()),
+        ),
+        InfoMode::Rules => (
+            format!("{name} - Rules"),
+            table
+                .table_info
+                .table_rules
+                .clone()
+                .filter(|x| !x.trim().is_empty())
+                .unwrap_or_else(|| "[no rules]".to_string()),
+        ),
+        InfoMode::Off => unreachable!(),
+    };
+
+    // Start new content at the top.
+    if let Ok(mut scroll_position) = scroll_query.single_mut() {
+        scroll_position.x = 0.0;
+        scroll_position.y = 0.0;
+    }
+    title_text.0 = title;
+    body_text.0 = body;
 }
 
 /// UI scrolling event.
@@ -196,52 +311,4 @@ fn send_scroll_events(
             }
         }
     }
-}
-
-fn handle_table_selection_changed(
-    mut event_reader: MessageReader<TableSelectionChanged>,
-    selected_item_res: Res<SelectedItem>,
-    tables: Res<VpxTables>,
-    mut title_text: Single<&mut Text, With<TitleNode>>,
-    mut body_text: Single<&mut Text, (With<BodyNode>, Without<TitleNode>)>,
-    mut scroll_query: Query<&mut ScrollPosition, With<BodyScroller>>,
-) {
-    // TODO only call this if the info panel is visible
-    //   apply the same update toggle_visibility
-    for _event in event_reader.read() {
-        update_view(
-            &selected_item_res,
-            &tables,
-            &mut title_text,
-            &mut body_text,
-            &mut scroll_query,
-        );
-    }
-}
-
-fn update_view(
-    selected_item_res: &Res<SelectedItem>,
-    tables: &Res<VpxTables>,
-    title_text: &mut Single<&mut Text, With<TitleNode>>,
-    body_text: &mut Single<&mut Text, (With<BodyNode>, Without<TitleNode>)>,
-    scroll_query: &mut Query<&mut ScrollPosition, With<BodyScroller>>,
-) {
-    let selected_item = selected_item_res.index.unwrap_or(0);
-    let table = &tables.indexed_tables[selected_item];
-    let gametext = table
-        .table_info
-        .table_description
-        .clone()
-        .filter(|x| !x.trim().is_empty())
-        .unwrap_or("[no description]".to_string());
-    let title = display_table_line(table);
-
-    // reset the scroll position to the top
-    if let Ok(mut scroll_position) = scroll_query.single_mut() {
-        scroll_position.x = 0.0;
-        scroll_position.y = 0.0;
-    }
-
-    title_text.0 = title;
-    body_text.0 = gametext;
 }


### PR DESCRIPTION
Pressing 1 now cycles the table info panel Off -> Description -> Rules -> Off instead of just toggling the description. Add a draggable scrollbar next to the scrolling body using bevy 0.19's headless Scrollbar/ScrollbarThumb widgets.