### PR TITLE
fix: stop requesting the vulkan validation layer

### DIFF
--- a/src/guifrontend.rs
+++ b/src/guifrontend.rs
@@ -12,6 +12,8 @@ use crate::windowing;
 use crate::windowing::WindowingPlugin;
 use bevy::platform::collections::HashSet;
 use bevy::prelude::*;
+use bevy::render::RenderPlugin;
+use bevy::render::settings::{InstanceFlags, RenderCreation, WgpuSettings};
 use bevy::window::*;
 use bevy_asset::UnapprovedPathMode;
 use std::io;
@@ -196,6 +198,19 @@ pub fn guifrontend(config: ResolvedConfig) -> io::Result<ExitCode> {
         .add_message::<TableSelectionChanged>()
         .add_plugins(
             DefaultPlugins
+                .set(RenderPlugin {
+                    // Don't request the Vulkan validation layer: on some drivers
+                    // (e.g. RADV) it spams benign validation errors at startup,
+                    // and it's a dev tool we don't ship. Other flags keep their
+                    // defaults (DEBUG labels in debug builds). No effect in
+                    // release, where validation is already off.
+                    render_creation: RenderCreation::Automatic(Box::new(WgpuSettings {
+                        instance_flags: InstanceFlags::default()
+                            .difference(InstanceFlags::VALIDATION),
+                        ..default()
+                    })),
+                    ..default()
+                })
                 .set(WindowPlugin {
                     primary_window: Some(playfield_window),
                     ..Default::default()


### PR DESCRIPTION
On some drivers (e.g. RADV/Mesa) the validation layer floods startup with benign validation errors (vulkanMemoryModel device scope, transient swapchain present/acquire ordering) that aren't real rendering bugs and aren't in our code. Configure RenderPlugin's WgpuSettings to drop InstanceFlags::VALIDATION (keeping other defaults like DEBUG labels). No effect in release builds, where validation is already off.

eg

```
2026-06-24T06:31:39.730333Z ERROR wgpu_hal::vulkan::instance: VALIDATION [VUID-RuntimeSpirv-vulkanMemoryModel-06265 (0x7ab8899)]
        vkCreateShaderModule(): SPIR-V uses Device memory scope, but the vulkanMemoryModelDeviceScope feature was not enabled.
%411 = OpAtomicIAdd %9 %412 %410 %38 %39
The Vulkan spec states: If the vulkanMemoryModel feature is enabled and the vulkanMemoryModelDeviceScope feature is not enabled, Device memory scope must not be used (https://docs.vulkan.org/spec/latest/appendices/spirvenv.html#VUID-RuntimeSpirv-vulkanMemoryModel-06265)
```

https://github.com/gfx-rs/wgpu/issues/9729
https://github.com/gfx-rs/wgpu/issues/9213