### PR TITLE
fix(deps): bump memmap2 to 0.9.11 (RUSTSEC-2026-0186)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4236,9 +4236,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
Patches an unsound out-of-bounds pointer offset in memmap2's advise_range/flush_range. Pulled in transitively via bevy_text -> parley -> fontique.

Closes #110