### PR TITLE
ci: disable scheduled security audit, keep manual dispatch

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,9 +1,11 @@
 name: Security audit
 
 on:
-  schedule:
-    # Run every Monday at 06:00 UTC.
-    - cron: '0 6 * * 1'
+  # Schedule disabled: the weekly run kept filing issues for transitive
+  # advisories we cannot act on.
+  # schedule:
+  #   # Run every Monday at 06:00 UTC.
+  #   - cron: '0 6 * * 1'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The weekly scheduled run keeps opening issues for transitive advisories that have no local fix. Keep the workflow for on-demand audits.